### PR TITLE
fix: typo with supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ This library provides a customizable dropdown component that enables users to:
 |:---------|:----------|
 | Android  | ✔️        |
 | iOS      | ✔️        |
-| JVM      | ✔️        |
-| Desktop  | ❌️        |
+| Desktop  | ✔️        |
+| Web      | ❌️        |
 
 ## 🚀 Installation
 See the releases section of this repository for the latest version.


### PR DESCRIPTION
There was a mistake in the README - `jvm` and `desktop` are the same and instead it should have been `web`. 

This PR addresses that typo and additionally, renamed `jvm`  to `desktop` for clarity.